### PR TITLE
Speedup : enable cuda tensors for IoU calculation during training

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,15 @@ We have verified that COCO val results of darknet are reproduced in the conditio
 - Numpy (verified as operable: 1.15.2)
 - OpenCV
 - Matplotlib
-- Pytorch (verified as operable: v0.4.0)
+- Pytorch (verified as operable: v0.4.0, v1.0.0)
 - Cython (verified as operable: v0.29.1)
 - [pycocotools](https://pypi.org/project/pycocotools/) (verified as operable: v2.0.0) 
+- Cuda (verified as operable: v9.0)
 
 optional:
 - tensorboard (>1.7.0)
 - [tensorboardX](https://github.com/lanpa/tensorboardX)
+- CuDNN (verified as operable: v7.0)
 
 #### Docker Environment
 

--- a/models/yolo_layer.py
+++ b/models/yolo_layer.py
@@ -100,7 +100,7 @@ class YOLOLayer(nn.Module):
             pred[..., :4] *= self.stride
             return pred.view(batchsize, -1, n_ch).data
 
-        pred = pred[..., :4].cpu().data
+        pred = pred[..., :4].data
 
         # target assignment
 
@@ -128,14 +128,14 @@ class YOLOLayer(nn.Module):
             n = int(nlabel[b])
             if n == 0:
                 continue
-            truth_box = torch.FloatTensor(np.zeros((n, 4)))
+            truth_box = dtype(np.zeros((n, 4)))
             truth_box[:n, 2] = truth_w_all[b, :n]
             truth_box[:n, 3] = truth_h_all[b, :n]
             truth_i = truth_i_all[b, :n]
             truth_j = truth_j_all[b, :n]
 
             # calculate iou between truth and reference anchors
-            anchor_ious_all = bboxes_iou(truth_box, self.ref_anchors)
+            anchor_ious_all = bboxes_iou(truth_box.cpu(), self.ref_anchors)
             best_n_all = np.argmax(anchor_ious_all, axis=1)
             best_n = best_n_all % 3
             best_n_mask = ((best_n_all == self.anch_mask[0]) | (

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -146,21 +146,21 @@ def bboxes_iou(bboxes_a, bboxes_b, xyxy=True):
 
     # top left
     if xyxy:
-        tl = np.maximum(bboxes_a[:, None, :2], bboxes_b[:, :2])
+        tl = torch.max(bboxes_a[:, None, :2], bboxes_b[:, :2])
         # bottom right
-        br = np.minimum(bboxes_a[:, None, 2:], bboxes_b[:, 2:])
+        br = torch.min(bboxes_a[:, None, 2:], bboxes_b[:, 2:])
         area_a = torch.prod(bboxes_a[:, 2:] - bboxes_a[:, :2], 1)
         area_b = torch.prod(bboxes_b[:, 2:] - bboxes_b[:, :2], 1)
     else:
-        tl = np.maximum((bboxes_a[:, None, :2] - bboxes_a[:, None, 2:] / 2),
+        tl = torch.max((bboxes_a[:, None, :2] - bboxes_a[:, None, 2:] / 2),
                         (bboxes_b[:, :2] - bboxes_b[:, 2:] / 2))
         # bottom right
-        br = np.minimum((bboxes_a[:, None, :2] + bboxes_a[:, None, 2:] / 2),
+        br = torch.min((bboxes_a[:, None, :2] + bboxes_a[:, None, 2:] / 2),
                         (bboxes_b[:, :2] + bboxes_b[:, 2:] / 2))
 
         area_a = torch.prod(bboxes_a[:, 2:], 1)
         area_b = torch.prod(bboxes_b[:, 2:], 1)
-    en = (tl < br).type(torch.FloatTensor).prod(dim=2)
+    en = (tl < br).type(tl.type()).prod(dim=2)
     area_i = torch.prod(br - tl, 2) * en  # * ((tl < br).all())
     return area_i / (area_a[:, None] + area_b - area_i)
 


### PR DESCRIPTION
IoU calculation between prediction and ground truth has been the bottleneck of the training pipeline.
In this PR, cuda tensors are made available for the calculation above.