### PR TITLE
Modify to change number of classes in YOLOv3 easily

### DIFF
--- a/models/yolo_layer.py
+++ b/models/yolo_layer.py
@@ -19,8 +19,6 @@ class YOLOLayer(nn.Module):
             ignore_thre (float): threshold of IoU above which objectness training is ignored.
         """
         super(YOLOLayer, self).__init__()
-        self.conv = nn.Conv2d(in_channels=in_ch,
-                              out_channels=255, kernel_size=1, stride=1, padding=0)
         self.anchors = [
             (10, 13), (16, 30), (33, 23),
             (30, 61), (62, 45), (59, 119),
@@ -28,6 +26,9 @@ class YOLOLayer(nn.Module):
         self.anch_mask = anch_mask
         self.n_anchors = 3
         self.n_classes = n_classes
+        self.conv = nn.Conv2d(in_channels=in_ch,
+                              out_channels=(5 + self.n_classes) * self.n_anchors,
+                              kernel_size=1, stride=1, padding=0)
         self.ignore_thre = ignore_thre
         self.l2_loss = nn.MSELoss(size_average=False)
         self.bce_loss = nn.BCELoss(size_average=False)
@@ -178,11 +179,11 @@ class YOLOLayer(nn.Module):
         # loss calculation
 
         output[..., 4] *= obj_mask
-        output[..., np.r_[0:4, 5:85]] *= tgt_mask
+        output[..., np.r_[0:4, 5:n_ch]] *= tgt_mask
         output[..., 2:4] *= tgt_scale
 
         target[..., 4] *= obj_mask
-        target[..., np.r_[0:4, 5:85]] *= tgt_mask
+        target[..., np.r_[0:4, 5:n_ch]] *= tgt_mask
         target[..., 2:4] *= tgt_scale
 
         bceloss = nn.BCELoss(weight=tgt_scale*tgt_scale,

--- a/models/yolov3.py
+++ b/models/yolov3.py
@@ -54,11 +54,12 @@ class resblock(nn.Module):
         return x
 
 
-def create_yolov3_modules(ignore_thre):
+def create_yolov3_modules(ignore_thre, n_classes):
     """
     Build yolov3 layer modules.
     Args:
         ignore_thre (float): used in YOLOLayer.
+        n_classes (int): number of classes
     Returns:
         mlist (ModuleList): YOLOv3 module list.
     """
@@ -82,7 +83,7 @@ def create_yolov3_modules(ignore_thre):
     # 1st yolo branch
     mlist.append(add_conv(in_ch=512, out_ch=1024, ksize=3, stride=1))
     mlist.append(
-        YOLOLayer(anch_mask=[6, 7, 8], n_classes=80, stride=32, in_ch=1024,
+        YOLOLayer(anch_mask=[6, 7, 8], n_classes=n_classes, stride=32, in_ch=1024,
             ignore_thre=ignore_thre))
 
     mlist.append(add_conv(in_ch=512, out_ch=256, ksize=1, stride=1))
@@ -94,7 +95,7 @@ def create_yolov3_modules(ignore_thre):
     # 2nd yolo branch
     mlist.append(add_conv(in_ch=256, out_ch=512, ksize=3, stride=1))
     mlist.append(
-        YOLOLayer(anch_mask=[3, 4, 5], n_classes=80, stride=16, in_ch=512,
+        YOLOLayer(anch_mask=[3, 4, 5], n_classes=n_classes, stride=16, in_ch=512,
              ignore_thre=ignore_thre))
 
     mlist.append(add_conv(in_ch=256, out_ch=128, ksize=1, stride=1))
@@ -103,7 +104,7 @@ def create_yolov3_modules(ignore_thre):
     mlist.append(add_conv(in_ch=128, out_ch=256, ksize=3, stride=1))
     mlist.append(resblock(ch=256, nblocks=2, shortcut=False))
     mlist.append(
-        YOLOLayer(anch_mask=[0, 1, 2], n_classes=80, stride=8, in_ch=256,
+        YOLOLayer(anch_mask=[0, 1, 2], n_classes=n_classes, stride=8, in_ch=256,
              ignore_thre=ignore_thre))
 
     return mlist
@@ -115,14 +116,15 @@ class YOLOv3(nn.Module):
     The network returns loss values from three YOLO layers during training \
     and detection results during test.
     """
-    def __init__(self, ignore_thre=0.7):
+    def __init__(self, ignore_thre=0.7, n_classes=80):
         """
         Initialization of YOLOv3 class.
         Args:
             ignore_thre (float): used in YOLOLayer.
+            n_classes (int): number of classes
         """
         super(YOLOv3, self).__init__()
-        self.module_list = create_yolov3_modules(ignore_thre)
+        self.module_list = create_yolov3_modules(ignore_thre, n_classes=n_classes)
 
     def forward(self, x, targets=None):
         """


### PR DESCRIPTION
# Why
- It is little difficult to change number of classes in YOLOv3 (for other dataset) now.

# How to test

I use [pytorch-summary](https://github.com/sksq96/pytorch-summary) for check it.

```python
import torch
from models.yolov3 import YOLOv3
from torchsummary import summary


def test(img_size: int=608, n_classes: int=80):
    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
    model = YOLOv3(n_classes=n_classes).to(device)
    print(f'* Print model structure, input_size=(3, {img_size}, {img_size})')
    summary(model, input_size=(3, img_size, img_size))


if __name__ == '__main__':
    test(img_size=608, n_classes=80)
    test(img_size=608, n_classes=10)
```

I try above script, and check each YOLOLayer(YOLOLayer-182, 207, 232) return [-1, XXX, 5 + n_class]