### PR TITLE
bugfix regarding target scaling used for wh loss

### DIFF
--- a/models/yolo_layer.py
+++ b/models/yolo_layer.py
@@ -175,7 +175,7 @@ class YOLOLayer(nn.Module):
                     target[b, a, j, i, 5 + labels[b, ti,
                                                   0].to(torch.int16).numpy()] = 1
                     tgt_scale[b, a, j, i, :] = torch.sqrt(
-                        2 - truth_x_all[b, ti] * truth_y_all[b, ti] / fsize / fsize)
+                        2 - truth_w_all[b, ti] * truth_h_all[b, ti] / fsize / fsize)
 
         # loss calculation
 


### PR DESCRIPTION
Target scaling for wh loss has been wrongly calculated.
The scaling factor ought to be (2 - target area), but has been (2 - target_x * target_y), where target_x and target_y range from 0 to 1.

This bugfix is being tested on a train-val sequence.