### PR TITLE
modify pytorch and python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ The models have been evaluated on the COCO 2017 val dataset using our repo.
 ## Installation
 #### Requirements
 
-- Python 3.6+
+- Python 3.6.3+
 - Numpy (verified as operable: 1.15.2)
 - OpenCV
 - Matplotlib
-- Pytorch (verified as operable: v0.4.0, v1.0.0)
+- Pytorch 1.0.0+ (verified as operable: v0.4.0, v1.0.0)
 - Cython (verified as operable: v0.29.1)
 - [pycocotools](https://pypi.org/project/pycocotools/) (verified as operable: v2.0.0) 
 - Cuda (verified as operable: v9.0)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@ ENV PYENV_ROOT /home/docker/.pyenv
 ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 RUN curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer | bash
 
-ENV PYTHON_VERSION 3.6.0
+ENV PYTHON_VERSION 3.6.8
 RUN pyenv install ${PYTHON_VERSION} && pyenv global ${PYTHON_VERSION}
 
 RUN pip install -U pip setuptools

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-torch==0.4.0
+torch==1.0.0
 numpy==1.15.2
 matplotlib==3.0.2
 opencv_python==3.4.4.19


### PR DESCRIPTION
Modify the pytorch and python versions to avoid freezing at `model.cuda()`
pytorch version : 1.0.0
python version : 3.6.8 (3.6.3+)